### PR TITLE
Avoiding a UnicodeDecodeError

### DIFF
--- a/channels_panel/utils.py
+++ b/channels_panel/utils.py
@@ -1,6 +1,7 @@
 import json
 import fnmatch
 import hashlib
+import sys
 import traceback
 from functools import wraps
 
@@ -12,12 +13,15 @@ from channels.utils import name_that_thing
 from . import GROUP_NAME_GROUPS, GROUP_PREFIX, _MARK
 from .settings import get_setting_value
 
+PY3K = sys.version_info >= (3, 0)
 
 class MessageJSONEncoder(DjangoJSONEncoder):
 
     def default(self, o):
         if isinstance(o, bytes):
-            return o.decode('utf-8')
+            if not PY3K:
+                return o.decode('utf-8')
+            return o.decode('utf-8', 'backslashreplace')
         return super(MessageJSONEncoder, self).default(o)
 
 


### PR DESCRIPTION
Thanks for your panel.

I was getting an "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 2: invalid
start byte" error. This PR works for me.

I am not sure what the correct solution is for the UTF8, I have chosen `backslashreplace`.

Some resources:
- http://stackoverflow.com/questions/606191/convert-bytes-to-a-python-string
- https://docs.python.org/3/howto/unicode.html#python-s-unicode-support